### PR TITLE
Production fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[1.2.1](https://github.com/sanger-tol/readmapping/releases/tag/1.2.1)] - [2024-02-27]
+
+### Enhancements & fixes
+
+- Increased the memory requests for reruns of BWAMEM2_MEM and SAMTOOLS_SORMADUP.
+
 ## [[1.2.0](https://github.com/sanger-tol/readmapping/releases/tag/1.2.0)] – Norwegian Ridgeback - [2023-12-19]
 
 ### Enhancements & fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[1.2.1](https://github.com/sanger-tol/readmapping/releases/tag/1.2.1)] - [2024-02-27]
+## [[1.2.1](https://github.com/sanger-tol/readmapping/releases/tag/1.2.1)] - [2024-02-29]
 
 ### Enhancements & fixes
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -4,33 +4,6 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Increasing the number of CPUs often gives diminishing returns, so we increase it
-    following a logarithm curve. Example:
-        - 0 < value <= 1: start + step
-        - 1 < value <= 2: start + 2*step
-        - 2 < value <= 4: start + 3*step
-        - 4 < value <= 8: start + 4*step
-    In order to support re-runs, the step increase may be multiplied by the attempt
-    number prior to calling this function.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-// Modified logarithm function that doesn't return negative numbers
-def positive_log(value, base) {
-    if (value <= 1) {
-        return 0
-    } else {
-        return Math.log(value)/Math.log(base)
-    }
-}
-
-def log_increase_cpus(start, step, value, base) {
-    return check_max(start + step * (1 + Math.ceil(positive_log(value, base))), 'cpus')
-}
-
-
 process {
 
     errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }

--- a/conf/base.config
+++ b/conf/base.config
@@ -113,7 +113,7 @@ process {
         time   = { check_max( 3.h * task.attempt *  Math.ceil(positive_log(meta2.genome_size/100000, 10)) * Math.ceil(meta.read_count/1000000000) * 12 / log_increase_cpus(6, 6*task.attempt, meta.read_count/1000000000, 2), 'time' ) }
         // Base RAM usage is about 6 times the genome size. Each thread takes an additional 800 MB RAM
         // Memory usage of SAMTOOLS_VIEW is negligible.
-        memory = { check_max( 6.GB * Math.ceil(meta2.genome_size / 1000000000) + 800.MB * log_increase_cpus(6, 6*task.attempt, meta.read_count/1000000000, 2), 'memory' ) }
+        memory = { check_max( 6.GB * Math.ceil(meta2.genome_size / 1000000000) + 800.MB * task.attempt * log_increase_cpus(6, 6*task.attempt, meta.read_count/1000000000, 2), 'memory' ) }
     }
 
     withName: MINIMAP2_ALIGN {

--- a/conf/base.config
+++ b/conf/base.config
@@ -82,7 +82,7 @@ process {
 
     withName: 'SAMTOOLS_SORMADUP' {
         cpus   = { log_increase_cpus(2, 6*task.attempt, 1, 2) }
-        memory = { check_max( 10.GB + 0.6.GB * Math.ceil( meta.read_count / 100000000 ) * task.attempt, 'memory' ) }
+        memory = { check_max( 4.GB + 850.MB * log_increase_cpus(2, 6*task.attempt, 1, 2) * task.attempt + 0.6.GB * Math.ceil( meta.read_count / 100000000 ), 'memory' ) }
         time   = { check_max( 2.h * Math.ceil( meta.read_count / 100000000 ) * task.attempt / log_increase_cpus(2, 6*task.attempt, 1, 2), 'time' ) }
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -183,7 +183,7 @@ manifest {
     description     = 'Pipeline to map reads generated using different sequencing technologies against a genome assembly.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.2.0'
+    version         = '1.2.1'
     doi             = '10.5281/zenodo.6563577'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -222,3 +222,30 @@ def check_max(obj, type) {
         }
     }
 }
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Increasing the number of CPUs often gives diminishing returns, so we increase it
+    following a logarithm curve. Example:
+        - 0 < value <= 1: start + step
+        - 1 < value <= 2: start + 2*step
+        - 2 < value <= 4: start + 3*step
+        - 4 < value <= 8: start + 4*step
+    In order to support re-runs, the step increase may be multiplied by the attempt
+    number prior to calling this function.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+// Modified logarithm function that doesn't return negative numbers
+def positive_log(value, base) {
+    if (value <= 1) {
+        return 0
+    } else {
+        return Math.log(value)/Math.log(base)
+    }
+}
+
+def log_increase_cpus(start, step, value, base) {
+    return check_max(start + step * (1 + Math.ceil(positive_log(value, base))), 'cpus')
+}
+


### PR DESCRIPTION
TOLIT-1928

This pull-request addresses MEMLIMIT errors found on BWAMEM2_MEM and SAMTOOLS_SORMADUP.
For both processes, the jobs were retried 5 times (as per `maxRetries`) and failed at _every_ attempt despite the resources (CPUs and memory) increasing.
This is because in both cases, the memory is a function of the number of CPUs: as the number of CPUs increases, so does the memory. But the config was such that the memory-per-CPU ratio was not increasing, or not fast enough, so retries could not address the initial MEMLIMIT problem.

The changes I propose are:

- for SAMTOOLS_SORMADUP: add a per-CPU component to the memory formula.
- for BWAMEM2_MEM: add the attempt number to the formula so that the memory-per-CPU ratio increases every attempt.

 In both cases, I'm not changing the baseline, but rather making sure that the second attempt gives enough memory for the job to succeed.

# bwamem2_mem

Initial failure: `/lustre/scratch122/tol/share/weskit/data/prod/03ba/03ba5c76-fccd-49da-a0cc-682362128eb1/exc_priority_1_readmapping/.nextflow.log` and `/lustre/scratch122/tol/share/weskit/data/prod/03ba/03ba5c76-fccd-49da-a0cc-682362128eb1/exc_priority_1_readmapping/work/bf/2ab57f0e97ef957747d31766cf5cf2/.command.log`

Successful run: `/lustre/scratch123/tol/teams/tolit/users/mm49/nextflow/rm/bwamem2` 


First attempt `/lustre/scratch123/tol/teams/tolit/users/mm49/nextflow/rm/bwamem2/work/86/e2ed519694856ac74b17ba380a5118/.command.log` (12 CPUs, 15.4 G RAM) failed because of MEMLIMIT 
Second attempt `/lustre/scratch123/tol/teams/tolit/users/mm49/nextflow/rm/bwamem2/work/ce/664d8f5406e98fb33390c3a966ce0d/.command.log` (18 CPUs, 34.1 GB RAM) succeeded (22.8 GB RAM used)

# sormadup

Initial failure: `/lustre/scratch122/tol/share/weskit/data/prod/ea13/ea1384a3-41d8-43ee-96d8-915731b14164/exc_priority_1_readmapping/.nextflow.log` and `/lustre/scratch122/tol/share/weskit/data/prod/ea13/ea1384a3-41d8-43ee-96d8-915731b14164/exc_priority_1_readmapping/work/7c/a7e6a393747ba7456d9174450850d3/.command.log`


Successful run: `/lustre/scratch123/tol/teams/tolit/users/mm49/nextflow/rm/sormadup`

First attempt `/lustre/scratch123/tol/teams/tolit/users/mm49/nextflow/rm/sormadup/work/ed/b2b47555f5ad665760931e4ff92a33/.command.log` (8 CPUs, 14.8 G RAM) failed because of MEMLIMIT 
Second attempt `/lustre/scratch123/tol/teams/tolit/users/mm49/nextflow/rm/sormadup/work/33/3f71dacd11dc58cd1605018dc24625/.command.log` (14 CPUs, 31.4 GB RAM) succeeded (27.2 GB RAM used)

---

I will make a release (v1.2.1) right after this pull-request is merged

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
