### PR TITLE
Fix when multiple PacBio files are given

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,15 +1,15 @@
 name: nf-core branch protection
-# This workflow is triggered on PRs to master branch on the repository
-# It fails when someone tries to make a PR against the nf-core `master` branch instead of `dev`
+# This workflow is triggered on PRs to main branch on the repository
+# It fails when someone tries to make a PR against the nf-core `main` branch instead of `dev`
 on:
   pull_request_target:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # PRs to the nf-core repo master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
+      # PRs to the nf-core repo main branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == 'sanger-tol/readmapping'
         run: |
@@ -22,7 +22,7 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            ## This PR is against the `master` branch :x:
+            ## This PR is against the `main` branch :x:
 
             * Do not close this PR
             * Click _Edit_ and change the `base` to `dev`
@@ -32,9 +32,9 @@ jobs:
 
             Hi @${{ github.event.pull_request.user.login }},
 
-            It looks like this pull-request is has been made against the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `master` branch.
-            The `master` branch on nf-core repositories should always contain code from the latest release.
-            Because of this, PRs to `master` are only allowed if they come from the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `dev` branch.
+            It looks like this pull-request is has been made against the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `main` branch.
+            The `main` branch on nf-core repositories should always contain code from the latest release.
+            Because of this, PRs to `main` are only allowed if they come from the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `dev` branch.
 
             You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
             Note that even after this, the test will continue to show as failing until you push a new commit.

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -18,6 +18,7 @@ lint:
     - assets/sendmail_template.txt
     - docs/README.md
     - lib/NfcoreTemplate.groovy
+    - .github/workflows/branch.yml
   nextflow_config:
     - manifest.name
     - manifest.homePage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[1.2.2](https://github.com/sanger-tol/readmapping/releases/tag/1.2.2)] - [2024-05-23]
+## [[1.2.2](https://github.com/sanger-tol/readmapping/releases/tag/1.2.2)] - Norwegian Ridgeback (patch 2) -[2024-05-23]
 
 ### Enhancements & fixes
 
 - Fixed the bug in the filtering of multiple PacBio files
 
-## [[1.2.1](https://github.com/sanger-tol/readmapping/releases/tag/1.2.1)] - [2024-02-29]
+## [[1.2.1](https://github.com/sanger-tol/readmapping/releases/tag/1.2.1)] - Norwegian Ridgeback (patch 1) - [2024-02-29]
 
 ### Enhancements & fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[1.2.2](https://github.com/sanger-tol/readmapping/releases/tag/1.2.2)] - [2024-05-23]
+
+### Enhancements & fixes
+
+- Fixed the bug in the filtering of multiple PacBio files
+
 ## [[1.2.1](https://github.com/sanger-tol/readmapping/releases/tag/1.2.1)] - [2024-02-29]
 
 ### Enhancements & fixes

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -3,3 +3,5 @@ mMelMel1,illumina,/lustre/scratch123/tol/resources/nextflow/test-data/Meles_mele
 mMelMel2,illumina,/lustre/scratch123/tol/resources/nextflow/test-data/Meles_meles/genomic_data/mMelMel2/illumina/31231_4#1.subset.cram,
 mMelMel3,hic,/lustre/scratch123/tol/resources/nextflow/test-data/Meles_meles/genomic_data/mMelMel3/hic/35528_2#1.subset.cram,
 mMelMel3,ont,/lustre/scratch123/tol/resources/nextflow/test-data/Meles_meles/genomic_data/mMelMel3/ont/PAE35587_pass_1f1f0707_115.subset.fastq.gz,
+mMelMel3,pacbio,/lustre/scratch123/tol/resources/nextflow/test-data/Meles_meles/genomic_data/mMelMel3/pacbio/m64094_200910_173211.ccs.bc1022_BAK8B_OA--bc1022_BAK8B_OA.subset.bam,
+mMelMel3,pacbio,/lustre/scratch123/tol/resources/nextflow/test-data/Meles_meles/genomic_data/mMelMel3/pacbio/m64094_200911_174739.ccs.bc1022_BAK8B_OA--bc1022_BAK8B_OA.subset.bam,

--- a/assets/samplesheet_s3.csv
+++ b/assets/samplesheet_s3.csv
@@ -3,3 +3,5 @@ mMelMel1,illumina,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_d
 mMelMel2,illumina,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel2/illumina/31231_4%231.subset.cram,
 mMelMel3,hic,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/hic/35528_2%231.subset.cram,
 mMelMel3,ont,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/ont/PAE35587_pass_1f1f0707_115.subset.fastq.gz,
+mMelMel3,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/pacbio/m64094_200910_173211.ccs.bc1022_BAK8B_OA--bc1022_BAK8B_OA.subset.bam,
+mMelMel3,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/pacbio/m64094_200911_174739.ccs.bc1022_BAK8B_OA--bc1022_BAK8B_OA.subset.bam,

--- a/modules/local/pacbio_filter.nf
+++ b/modules/local/pacbio_filter.nf
@@ -11,8 +11,8 @@ process PACBIO_FILTER {
     tuple val(meta), path(txt)
 
     output:
-    path("*.blocklist"),  emit: list
-    path  "versions.yml", emit: versions
+    tuple val(meta), path("*.blocklist"), emit: list
+    path  "versions.yml"                , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/nextflow.config
+++ b/nextflow.config
@@ -183,7 +183,7 @@ manifest {
     description     = 'Pipeline to map reads generated using different sequencing technologies against a genome assembly.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.2.1'
+    version         = '1.2.2'
     doi             = '10.5281/zenodo.6563577'
 }
 

--- a/subworkflows/local/filter_pacbio.nf
+++ b/subworkflows/local/filter_pacbio.nf
@@ -60,9 +60,18 @@ workflow FILTER_PACBIO {
     // Create filtered BAM file
     SAMTOOLS_CONVERT.out.bam
     | join ( SAMTOOLS_CONVERT.out.csi )
+    | join ( PACBIO_FILTER.out.list )
+    | set { ch_reads_and_list }
+
+    ch_reads_and_list
+    | map { meta, bam, csi, list -> [meta, bam, csi] }
     | set { ch_reads }
 
-    SAMTOOLS_FILTER ( ch_reads, [ [], [] ], PACBIO_FILTER.out.list )
+    ch_reads_and_list
+    | map { meta, bam, csi, list -> list }
+    | set { ch_lists }
+
+    SAMTOOLS_FILTER ( ch_reads, [ [], [] ], ch_lists )
     ch_versions = ch_versions.mix ( SAMTOOLS_FILTER.out.versions.first() )
 
 


### PR DESCRIPTION
The bug occurred when there were multiple PacBio files. SAMTOOLS_FILTER was getting unsynchronised data from `ch_reads` and `PACBIO_FILTER.out.list`. The fix is to pair elements in those two channels before feeding SAMTOOLS_FILTER.

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
