### PR TITLE
Fix broken full CI test 

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -74,6 +74,7 @@ try {
 
 // Load sanger-tol/readmapping custom profiles from different institutions.
 profiles {
+    cleanup { cleanup = true }
     debug {
         dumpHashes              = true
         process.beforeScript    = 'echo $HOSTNAME'


### PR DESCRIPTION
I introduced a chance during the nf-core updates which broke the full CI. Now fixed.

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
