### PR TITLE
spoof REF_PATH to disallow remote lookup for cram

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -12,6 +12,7 @@
 
 process {
     withName: SAMTOOLS_FASTQ {
+        beforeScript = { "export REF_PATH=spoof"}
         ext.args = '-F 0x200 -nt'
     }
 
@@ -24,6 +25,7 @@ process {
     }
 
     withName: SAMTOOLS_MERGE {
+        beforeScript = { "export REF_PATH=spoof"}
         ext.args = { "-c -p" }
         ext.prefix = { "${meta.id}.merge" }
     }
@@ -35,6 +37,7 @@ process {
     }
 
     withName: SAMTOOLS_COLLATETOFASTA {
+        beforeScript = { "export REF_PATH=spoof"}
         ext.args   = { (params.use_work_dir_as_temp ? "-T." : "") }
     }
 
@@ -43,6 +46,7 @@ process {
     }
 
     withName: SAMTOOLS_CONVERT {
+        beforeScript = { "export REF_PATH=spoof"}
         ext.args = "-be '[rq]>=0.99' -x fi -x fp -x ri -x rp --write-index"
     }
 
@@ -64,6 +68,7 @@ process {
     }
 
     withName: '.*:CONVERT_STATS:SAMTOOLS_CRAM' {
+        beforeScript = { "export REF_PATH=spoof"}
         ext.prefix = { "${fasta.baseName}.${meta.datatype}.${meta.id}" }
         ext.args   = '--output-fmt cram --write-index'
     }
@@ -82,6 +87,7 @@ process {
     }
 
     withName: SAMTOOLS_STATS {
+        beforeScript = { "export REF_PATH=spoof"}
         ext.prefix = { "${input.baseName}" }
     }
 
@@ -91,6 +97,7 @@ process {
     }
 
     withName: '.*:CONVERT_STATS:SAMTOOLS_.*' {
+        beforeScript = { "export REF_PATH=spoof"}
         publishDir = [
             path: { "${params.outdir}/read_mapping/${meta.datatype}" },
             mode: params.publish_dir_mode,


### PR DESCRIPTION
Attempts to pre-empt problems in CRAM processing, using the solution discussed in [#111](https://github.com/sanger-tol/readmapping/issues/111)

Closes [#111](https://github.com/sanger-tol/readmapping/issues/111)

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
