### PR TITLE
cram_filter runtime

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -116,11 +116,13 @@ process {
     }
 
     withName: CRAM_FILTER_MINIMAP2_FILTER5END_FIXMATE_SORT {
+        time    = { check_max( 16.h  * task.attempt, 'time'    ) }
         cpus    = { check_max( 16       * 1                                                            , 'cpus'   ) }
         memory  = { check_max( 1.GB     * ( reference.size() < 2e9 ? 50 : Math.ceil( ( reference.size() / 1e+9 ) * 20 ) * Math.ceil( task.attempt * 1 ) ) , 'memory') }
     }
 
     withName: CRAM_FILTER_ALIGN_BWAMEM2_FIXMATE_SORT {
+        time    = { check_max( 16.h  * task.attempt, 'time'    ) }
         cpus    = { check_max( 16       * 1                                                 , 'cpus'   ) }
         memory  = { check_max( 1.GB     * ( reference.size() < 2e9 ? 50 : Math.ceil( ( reference.size() / 1e+9 ) * 20 ) * Math.ceil( task.attempt * 1 ) ) , 'memory') }
     }

--- a/conf/test.config
+++ b/conf/test.config
@@ -23,7 +23,7 @@ params {
     input = "${projectDir}/assets/samplesheet_s3.csv"
 
     // Output directory
-    outdir = "${projectDir}/results"
+    outdir = "./results"
 
     // Aligner
     short_aligner = "minimap2"

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -18,7 +18,7 @@ params {
     input = "${projectDir}/assets/samplesheet_full.csv"
 
     // Output directory
-    outdir = "${projectDir}/results"
+    outdir = "./results"
 
     // Fasta references
     fasta = "/lustre/scratch124/tol/projects/darwin/data/insects/Polyommatus_icarus/assembly/release/ilPolIcar1.1/insdc/GCA_937595015.1.fasta.gz"


### PR DESCRIPTION
The recent "full_test" runs failed on `dev` because of RUNLIMIT errors (error code 140) in the cram_filter chunk aligners, cf https://sanger.enterprise.slack.com/files/USLACKBOT/F08EXETKTBK/run__focused_lalande__-_failed_

In Treeval, from where the cram_filter processes are copied, the `time` parameter was implicitly set via the `process_high` label which we don't have in this pipeline. Instead I directly set it at the process level.

I also change the default value of `outdir` so that the output directory is where the pipeline is run from.


<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
