### PR TITLE
More memory for crumble !

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[1.3.4](https://github.com/sanger-tol/readmapping/releases/tag/1.3.4)] - Antipodean Opaleye (patch 4) - [2025-03-18]
+
+### Enhancements & fixes
+
+- Even more memory for CRUMBLE
+
 ## [[1.3.3](https://github.com/sanger-tol/readmapping/releases/tag/1.3.3)] - Antipodean Opaleye (patch 3) - [2025-02-10]
 
 ### Enhancements & fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: sanger-tol/readmapping v1.3.4
+type: software
+authors:
+    - given-names: Sandra Ruth
+      family-names: Babirye
+      affiliation: Wellcome Sanger Institute
+      orcid: "https://orcid.org/0009-0004-7773-7008"
+    - given-names: Tyler
+      family-names: Chafin
+      affiliation: Wellcome Sanger Institute
+      orcid: "https://orcid.org/0000-0001-8687-5905"
+    - given-names: Chau
+      family-names: Duong
+      affiliation: Wellcome Sanger Institute
+      orcid: "https://orcid.org/0009-0001-0649-2291"
+    - given-names: Matthieu
+      family-names: Muffato
+      affiliation: Wellcome Sanger Institute
+      orcid: "https://orcid.org/0000-0002-7860-3560"
+    - given-names: Guoying
+      family-names: Qi
+      affiliation: Wellcome Sanger Institute
+      orcid: "https://orcid.org/0000-0003-1262-8973"
+    - given-names: Priyanka
+      family-names: Surana
+      affiliation: Wellcome Sanger Institute
+      orcid: "https://orcid.org/0000-0002-7167-0875"
+    - given-names: Bethan
+      family-names: Yates
+      affiliation: Wellcome Sanger Institute
+      orcid: "https://orcid.org/0000-0003-1658-1762"
+identifiers:
+    - type: doi
+      value: 10.5281/zenodo.6563577
+repository-code: "https://github.com/sanger-tol/readmapping"
+license: MIT
+version: 1.3.4
+date-released: "2022-10-07"

--- a/conf/base.config
+++ b/conf/base.config
@@ -105,9 +105,7 @@ process {
 
     withName: CRUMBLE {
         // Most genomes seem happy with 1 GB, but some need a bit more, and others a lot more.
-        // There is a weak, but existing, correlation between memory usage and the number of reads.
-        // The formula below is a quadratic growth based on the attempt number.
-        memory = { check_max( task.attempt * (task.attempt + 1) * 512.MB * Math.ceil( meta.read_count / 1000000000 ), 'memory' ) }
+        memory = { check_max( 1.GB * Math.pow(3, task.attempt-1), 'memory' ) }
         // 100k reads per hour for PacBio, 50m for HiC
         time   = { check_max( 1.h  * Math.ceil( meta.read_count / (meta.datatype == "pacbio" ? 100000 : 50000000)) * task.attempt, 'time'   ) }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -232,7 +232,7 @@ manifest {
     description     = 'Pipeline to map reads generated using different sequencing technologies against a genome assembly.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.3.3'
+    version         = '1.3.4'
     doi             = '10.5281/zenodo.6563577'
 }
 


### PR DESCRIPTION
The previous code was attempting Crumble with 1 GB, 3, 6, 10, 15, 21 (with the recent addition of a multiplier based on the number of reads).

Across the recent runs, a bunch of species failed at 21 GB. They needed 29 GB. Other species failed at 21*2=42 GB. They needed 48, 51, 58, 59, or 108 GB.

The formula 3^(attempt-1) will provide the following sequence:
 1 GB, 3, 9, 27, 81, 243
It provides a >2-fold cushion at the high end of the distribution. If it still fails, we would then move to 4^(attempt-1):
 1 GB, 4, 16, 64, 256, 1024.
which I want to avoid for now in order to minimise wastage.

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
