### PR TITLE
Support CSI files too

### DIFF
--- a/subworkflows/local/convert_stats.nf
+++ b/subworkflows/local/convert_stats.nf
@@ -81,7 +81,7 @@ workflow CONVERT_STATS {
 
         // Set the BAM and BAI channels for emission
         ch_bam = SAMTOOLS_REINDEX.out.bam
-        ch_bai = SAMTOOLS_REINDEX.out.bai
+        ch_bai = SAMTOOLS_REINDEX.out.bai.mix(SAMTOOLS_REINDEX.out.csi)
 
         // If using BAM for stats, use the reindexed BAM
         if ( !("cram" in outfmt_options) ) {


### PR DESCRIPTION
This pull-request is inspired by our discussion this morning on the problems with `-resume` you've faced when testing these [changes](https://github.com/sanger-tol/readmapping/compare/b4eb1af...1f5e0c3#diff-65b938a887103d43c22da27f486acc58c49bfcc02884052ba133bfa9e7a5f2e1) for #171.

`ch_bai` is meant to be the channel of the BAM index that is then used as an output of the sub-worfkflow (in `emit:`). The same variable name should be used when initialising it to an empty channel, getting the output of SAMTOOLS_REINDEX, and putting into ch_data_for_stats.
It's good to add support for CSI, but the way the nf-core samtools module works, they're in [different output channels and mutually exclusive](https://github.com/sanger-tol/readmapping/blob/1.3.4/modules/nf-core/samtools/view/main.nf#L19-L20). Rather than changing to just CSI, I propose to simply mix the two channels. So that `ch_bai` remains the one variable we use, and it will have whatever index was created by samtools.

I don't know if this change would have fixed your issue with `-resume`, I haven't tested that.

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
