### PR TITLE
"change_name" process and configuration of output file name

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -166,7 +166,7 @@ process {
             // Only publish BAM/CRAM from SAMTOOLS_REHEADER if params.header is true, else from: SAMTOOLS_INDEX (BAM) and SAMTOOLS_CRAM (CRAM)
             saveAs: { filename ->
                 filename == 'versions.yml'
-                || ((task.process == 'CHANGE_NAME') || (task.process == 'SAMTOOLS_CRAM' && !file.name.endsWith('.cram')) 
+                || ((task.process == 'CHANGE_NAME') || (task.process == 'SAMTOOLS_CRAM' && !file.name.endsWith('.cram'))
                     && params.header)
                 || ((task.process =~ /SAMTOOLS_CRAM/) && filename.endsWith(".bam"))
                 ? null : filename

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -166,7 +166,8 @@ process {
             // Only publish BAM/CRAM from SAMTOOLS_REHEADER if params.header is true, else from: SAMTOOLS_INDEX (BAM) and SAMTOOLS_CRAM (CRAM)
             saveAs: { filename ->
                 filename == 'versions.yml'
-                || ((task.process =~ /SAMTOOLS_INDEX|SAMTOOLS_CRAM/) && params.header)
+                || ((task.process == 'CHANGE_NAME') || (task.process == 'SAMTOOLS_CRAM' && !file.name.endsWith('.cram')) 
+                    && params.header)
                 || ((task.process =~ /SAMTOOLS_CRAM/) && filename.endsWith(".bam"))
                 ? null : filename
             }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -131,7 +131,7 @@ process {
 
     withName: '.*:CONVERT_STATS:SAMTOOLS_CRAM' {
         beforeScript = { "export REF_PATH=spoof"}
-        ext.prefix = { "${fasta.baseName}.${meta.datatype}.${meta.id}" }
+        ext.prefix = { "${input.baseName}" }
         ext.args   = '--output-fmt cram --write-index'
     }
 
@@ -171,7 +171,7 @@ process {
     }
 
     withName: 'BLOBTK_DEPTH' {
-        ext.prefix = { "${meta.fasta}.${meta.datatype}.${meta.id}" }
+        ext.prefix = { "${bam.baseName}" }
     }
 
     withName: 'BGZIP_BEDGRAPH' {
@@ -179,7 +179,7 @@ process {
     }
 
     withName: 'CHANGE_NAME' {
-        ext.prefix = { "${meta.fasta}.${meta.datatype}.${meta.id}" }
+        ext.prefix = { "${fasta.baseName}.${meta.datatype}.${meta.id}" }
     }
 
     withName: FASTQC {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -158,14 +158,17 @@ process {
         ext.args   = { (meta.datatype == "pacbio" ? "-y pbccs " : "") + "-O bam" }
     }
 
-    withName: '.*:CONVERT_STATS:SAMTOOLS_.*|BGZIP_BEDGRAPH|CHANGE_NAME' {
+    withName: '.*:CONVERT_STATS:SAMTOOLS_.*|BGZIP_BEDGRAPH' {
         beforeScript = { "export REF_PATH=spoof" }
         publishDir = [
             path: { "${params.outdir}/read_mapping/${meta.datatype}${meta.merged ? '/merged' : ''}" },
             mode: params.publish_dir_mode,
-            // Only publish BAM/CRAM from SAMTOOLS_REHEADER if params.header is true, else from: CHANGE_NAME and SAMTOOLS_CRAM
+            // Only publish BAM/CRAM from SAMTOOLS_REHEADER if params.header is true, else from: SAMTOOLS_INDEX (BAM) and SAMTOOLS_CRAM (CRAM)
             saveAs: { filename ->
-                filename == 'versions.yml' || ((task.process =~ /CHANGE_NAME|SAMTOOLS_CRAM/) && params.header) ? null : filename
+                filename == 'versions.yml'
+                || ((task.process =~ /SAMTOOLS_INDEX|SAMTOOLS_CRAM/) && params.header)
+                || ((task.process =~ /SAMTOOLS_CRAM/) && filename.endsWith(".bam"))
+                ? null : filename
             }
         ]
     }

--- a/modules.json
+++ b/modules.json
@@ -58,7 +58,8 @@
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "46eca555142d6e597729fcb682adcc791796f514",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/samtools/index/samtools-index.diff"
                     },
                     "samtools/merge": {
                         "branch": "master",

--- a/modules/local/change_name.nf
+++ b/modules/local/change_name.nf
@@ -4,6 +4,7 @@ process CHANGE_NAME {
 
     input:
     tuple val(meta), path(file)
+    tuple val(meta2), path(fasta)
 
     output:
     tuple val(meta), path("*.${file.extension}"), emit: file

--- a/modules/nf-core/samtools/index/main.nf
+++ b/modules/nf-core/samtools/index/main.nf
@@ -11,6 +11,7 @@ process SAMTOOLS_INDEX {
     tuple val(meta), path(input)
 
     output:
+    tuple val(meta), path("${input}"), emit: input
     tuple val(meta), path("*.bai") , optional:true, emit: bai
     tuple val(meta), path("*.csi") , optional:true, emit: csi
     tuple val(meta), path("*.crai"), optional:true, emit: crai

--- a/modules/nf-core/samtools/index/samtools-index.diff
+++ b/modules/nf-core/samtools/index/samtools-index.diff
@@ -1,0 +1,20 @@
+Changes in component 'nf-core/samtools/index'
+'modules/nf-core/samtools/index/meta.yml' is unchanged
+Changes in 'samtools/index/main.nf':
+--- modules/nf-core/samtools/index/main.nf
++++ modules/nf-core/samtools/index/main.nf
+@@ -11,6 +11,7 @@
+     tuple val(meta), path(input)
+ 
+     output:
++    tuple val(meta), path("${input}"), emit: input
+     tuple val(meta), path("*.bai") , optional:true, emit: bai
+     tuple val(meta), path("*.csi") , optional:true, emit: csi
+     tuple val(meta), path("*.crai"), optional:true, emit: crai
+
+'modules/nf-core/samtools/index/environment.yml' is unchanged
+'modules/nf-core/samtools/index/tests/csi.nextflow.config' is unchanged
+'modules/nf-core/samtools/index/tests/main.nf.test' is unchanged
+'modules/nf-core/samtools/index/tests/tags.yml' is unchanged
+'modules/nf-core/samtools/index/tests/main.nf.test.snap' is unchanged
+************************************************************

--- a/subworkflows/local/convert_stats.nf
+++ b/subworkflows/local/convert_stats.nf
@@ -32,12 +32,6 @@ workflow CONVERT_STATS {
     // Split outfmt parameter into a list
     def outfmt_options = params.outfmt.split(',').collect { it.trim() }
 
-    // Reserve fasta base name for prefix of CHANGE_NAME and BLOBTK_DEPTH
-    bam
-    .combine( fasta )
-    .map{ meta, bam, meta1, fasta -> [ meta +[fasta:fasta.baseName], bam]}
-    .set { bam }
-
     // (Optionally) Compress the quality scores of Illumina and PacBio CCS alignments
     if ( params.compression == "crumble" ) {
         bam
@@ -53,14 +47,19 @@ workflow CONVERT_STATS {
 
         CRUMBLE.out.bam
         | mix( crumble_selector.no_crumble )
-        | map { meta, bam -> [meta, bam, []] }
         | set { ch_bams_for_conversion }
 
     } else {
-        bam
-        | map { meta, bam -> [meta, bam, []] }
-        | set { ch_bams_for_conversion }
+        ch_bams_for_conversion = bam
     }
+
+
+    // Change name of BAM files to final name for publishing
+    CHANGE_NAME ( ch_bams_for_conversion, fasta )
+
+    CHANGE_NAME.out.file
+    | map { meta, bam -> [meta, bam, []] }
+    | set { ch_renamed_bams }
 
 
     // (Optionally) convert to CRAM if it's specified in outfmt
@@ -68,15 +67,12 @@ workflow CONVERT_STATS {
     ch_crai = Channel.empty()
 
     if ("cram" in outfmt_options) {
-        SAMTOOLS_CRAM ( ch_bams_for_conversion, fasta, [] )
+        SAMTOOLS_CRAM ( ch_renamed_bams, fasta, [] )
         ch_versions = ch_versions.mix( SAMTOOLS_CRAM.out.versions.first() )
 
         // Combine CRAM and CRAI into one channel
         ch_cram = SAMTOOLS_CRAM.out.cram
         ch_crai = SAMTOOLS_CRAM.out.crai
-        ch_data_for_stats = ch_cram.join( ch_crai )
-    } else {
-        ch_data_for_stats = ch_bams_for_conversion
     }
 
 
@@ -85,22 +81,15 @@ workflow CONVERT_STATS {
     ch_bai = Channel.empty()
 
     if ("bam" in outfmt_options) {
-        ch_bams_to_index = ch_bams_for_conversion.map{ it -> [it[0], it[1]]}
-        // Change name of BAM files to final name for publishing
-        ch_bam = CHANGE_NAME ( ch_bams_to_index ).file
-
         // Reindex BAM
-        SAMTOOLS_INDEX ( ch_bam )
+        SAMTOOLS_INDEX ( CHANGE_NAME.out.file )
         ch_versions = ch_versions.mix( SAMTOOLS_INDEX.out.versions.first() )
 
         // Set the BAM and BAI channels for emission
+        ch_bam = CHANGE_NAME.out.file
         ch_bai = SAMTOOLS_INDEX.out.bai.mix(SAMTOOLS_INDEX.out.csi)
-
-        // If using BAM for stats, use the reindexed BAM
-        if ( !("cram" in outfmt_options) ) {
-            ch_data_for_stats = ch_bam.join ( SAMTOOLS_INDEX.out.bai )
-        }
     }
+
 
     // Optionally insert params.header information to bams
     if ( params.header ) {
@@ -112,7 +101,7 @@ workflow CONVERT_STATS {
 
 
     // Calculate read depth
-    BLOBTK_DEPTH ( ch_bams_for_conversion )
+    BLOBTK_DEPTH ( ch_renamed_bams )
     ch_versions = ch_versions.mix( BLOBTK_DEPTH.out.versions.first() )
 
     BGZIP_BEDGRAPH ( BLOBTK_DEPTH.out.bedgraph )
@@ -120,17 +109,15 @@ workflow CONVERT_STATS {
 
 
     // Calculate statistics
-    SAMTOOLS_STATS ( ch_data_for_stats, fasta )
+    SAMTOOLS_STATS ( ch_renamed_bams, [[], []] )
     ch_versions = ch_versions.mix( SAMTOOLS_STATS.out.versions.first() )
 
-
     // Calculate statistics based on flag values
-    SAMTOOLS_FLAGSTAT ( ch_data_for_stats )
+    SAMTOOLS_FLAGSTAT ( ch_renamed_bams )
     ch_versions = ch_versions.mix( SAMTOOLS_FLAGSTAT.out.versions.first() )
 
-
     // Calculate index statistics
-    SAMTOOLS_IDXSTATS ( ch_data_for_stats )
+    SAMTOOLS_IDXSTATS ( ch_renamed_bams )
     ch_versions = ch_versions.mix( SAMTOOLS_IDXSTATS.out.versions.first() )
 
 

--- a/subworkflows/local/convert_stats.nf
+++ b/subworkflows/local/convert_stats.nf
@@ -73,6 +73,7 @@ workflow CONVERT_STATS {
         // Combine CRAM and CRAI into one channel
         ch_cram = SAMTOOLS_CRAM.out.cram
         ch_crai = SAMTOOLS_CRAM.out.crai
+        ch_for_stats = ch_cram.join( ch_crai )
     }
 
 
@@ -88,6 +89,11 @@ workflow CONVERT_STATS {
         // Set the BAM and BAI channels for emission
         ch_bam = CHANGE_NAME.out.file
         ch_bai = SAMTOOLS_INDEX.out.bai.mix(SAMTOOLS_INDEX.out.csi)
+
+        if ( !('cram' in outfmt_options) ) {
+            ch_for_stats = ch_bam.join( ch_bai )
+        }
+
     }
 
 
@@ -107,17 +113,16 @@ workflow CONVERT_STATS {
     BGZIP_BEDGRAPH ( BLOBTK_DEPTH.out.bedgraph )
     ch_versions = ch_versions.mix( BGZIP_BEDGRAPH.out.versions.first() )
 
-
     // Calculate statistics
-    SAMTOOLS_STATS ( ch_renamed_bams, [[], []] )
+    SAMTOOLS_STATS (ch_for_stats, [[], []] )
     ch_versions = ch_versions.mix( SAMTOOLS_STATS.out.versions.first() )
 
     // Calculate statistics based on flag values
-    SAMTOOLS_FLAGSTAT ( ch_renamed_bams )
+    SAMTOOLS_FLAGSTAT ( ch_for_stats )
     ch_versions = ch_versions.mix( SAMTOOLS_FLAGSTAT.out.versions.first() )
 
     // Calculate index statistics
-    SAMTOOLS_IDXSTATS ( ch_renamed_bams )
+    SAMTOOLS_IDXSTATS ( ch_for_stats )
     ch_versions = ch_versions.mix( SAMTOOLS_IDXSTATS.out.versions.first() )
 
 

--- a/subworkflows/local/convert_stats.nf
+++ b/subworkflows/local/convert_stats.nf
@@ -47,15 +47,15 @@ workflow CONVERT_STATS {
 
         CRUMBLE.out.bam
         | mix( crumble_selector.no_crumble )
-        | set { ch_bams_for_conversion }
+        | set { ch_bams_for_renaming }
 
     } else {
-        ch_bams_for_conversion = bam
+        ch_bams_for_renaming = bam
     }
 
 
     // Change name of BAM files to final name for publishing
-    CHANGE_NAME ( ch_bams_for_conversion, fasta )
+    CHANGE_NAME ( ch_bams_for_renaming, fasta )
 
     CHANGE_NAME.out.file
     | map { meta, bam -> [meta, bam, []] }


### PR DESCRIPTION
I found it a bit confusing to have so many channels of BAM files in `subworkflows/local/convert_stats.nf`, and also the fact that we define the name of the output files multiple times in `conf/modules.config`.

The core of my proposal is to pass _all_ BAM files through `change_name`, define the output name there just once, and then to make all subsequent steps use something like `input.baseName` as their "task prefix".

To avoid having to make a channel that combines BAM files with the input fasta, it can simply be passed as an extra input channel in `change_name`.
The channels used in the module are:

1. `bam`: list of input BAM files
2. `ch_bams_for_renaming`: list of BAM files, now compressed with `crumble` if requested. ready to go through `change_name`
3. `ch_renamed_bams`. Same BAM files as `ch_bams_for_renaming` but now renamed.
     1. `ch_renamed_bams` is used in the conversion to CRAM,  `blobtk_depth` and all the samtools \*stats processes
     2. There are two places where I instead use `CHANGE_NAME.out.file`. This is because `CHANGE_NAME.out.file` is just `[meta, bam]` whereas as is `ch_renamed_bams` is `[meta, bam, []]`. Maybe you'd want to introduce another variable name to make the distinction clearer ? Or do a `map` from `ch_renamed_bams` on the fly ?

I hoped publishing the files would be trivial but it wasn't.
Because `CHANGE_NAME` is now used for everything, it'll make a BAM file even when `outfmt` is set to `cram`. I therefore fully removed `CHANGE_NAME` from the publishing rule with the objective of doing something like this:

- CRAM and CRAM index files are published from `SAMTOOLS_CRAM`
- BAM and BAM index files are published from `SAMTOOLS_INDEX`

The problems were that:

1. `SAMTOOLS_CRAM` is an instance of `samtools/view`, which puts the input BAM file in an output channel. So I had to add `((task.process =~ /SAMTOOLS_CRAM/) && filename.endsWith(".bam"))` to exclude it
2. I had to patch `SAMTOOLS_INDEX` to output the input file as well.

So overall, I think it's maybe a bit simpler in terms of channels and processes in the sub-workflow, but publishing the output files is more complex and maybe harder to maintain.

What do you think ? Is it worth it at all ?

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
