### PR TITLE
Added the embed_ref=2 option and some documentation

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -220,7 +220,10 @@ process {
 
     withName: '.*:CONVERT_STATS:SAMTOOLS_CRAM' {
         ext.prefix = { "${input.baseName}" }
-        ext.args   = "--output-fmt cram,version=3.0,archive,level=8 --write-index"
+        // version=3.0 because 3.1 is not yet supported by htsjdk and many other software
+        // archive,level=8 to get maximum compression but without the extra compute time of lzma, cf https://www.htslib.org/benchmarks/CRAM.html
+        // embed_ref=2 so that the CRAM files can be used without having to link / download the reference genome
+        ext.args   = "--output-fmt cram,version=3.0,archive,level=8,embed_ref=2 --write-index"
     }
 
     withName: '.*:CONVERT_STATS:SAMTOOLS_(INDEX|CRAM|REHEADER_.*|FLAGSTAT|IDXSTATS)|BGZIP_BEDGRAPH|GZIP_STATS' {


### PR DESCRIPTION
The default behaviour of CRAM files is to have an [external reference](https://www.htslib.org/doc/reference_seqs.html). This is why many commands that take a CRAM file in also require a Fasta file. Other commands often transparently try to download the reference sequences from ENA, which can be slow, or circumvented by creating a local cache of all sequences.
In other words, it's a bit inconvenient.

The `embed_ref=2` option is a compromise: the reference sequence is stored _in_ the CRAM file so that it works standalone. In my tests with the `test` profile, the CRAM with `embed_ref=2` has got about the same size as the one with an external Fasta reference, so size-wise it there isn't a significant penalty.

I've added some comments to explain this a bit.

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
