### PR TITLE
Only grab the actual RG line, not just any line that mentions it

### DIFF
--- a/bin/generate_cram_csv.sh
+++ b/bin/generate_cram_csv.sh
@@ -18,7 +18,7 @@ chunk_cram() {
     local crai=$4
     local chunk_size=$5
 
-    local rgline=$(samtools view -H "${realcram}" | grep "@RG" | sed 's/\t/\\t/g' | sed "s/'//g")
+    local rgline=$(samtools view -H "${realcram}" | grep "^@RG" | sed 's/\t/\\t/g' | sed "s/'//g")
     local ncontainers=$(zcat "${realcrai}" | wc -l)
     local base=$(basename "${realcram}" .cram)
 


### PR DESCRIPTION
A step towards closing #137 

I've tried running the pipeline on already-aligned data, using BAM for now to avoid trouble with CRAM. Here is how I prepared the inputs:

1. Run the test profile as usual
2. Convert all the output CRAM files to BAM
3. Create a copy of the test samplesheet that points at all those aligned BAM files
4. Run the pipeline on this samplesheet

The issue I found is simple. `bin/generate_cram_csv.sh` was grabbing a `@PG` line from a previous command that contained `@RG ...` in it, instead of the normal `@RG` line.
I know this change may be obsolete with the upcoming move to sanger-tol sub-workflows. Fine to fix it there !

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
