### PR TITLE
More strict linting

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -37,7 +37,7 @@
                     },
                     "gunzip": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "96c57dfd98a0641886a67bd449fe33ee2ec0e374",
                         "installed_by": ["modules"]
                     },
                     "lima": {
@@ -47,7 +47,7 @@
                     },
                     "minimap2/align": {
                         "branch": "master",
-                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
+                        "git_sha": "a1589a1910c7b19f9cb9db98b3641d883a45bf4b",
                         "installed_by": ["modules"]
                     },
                     "minimap2/index": {
@@ -137,7 +137,7 @@
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
-                        "git_sha": "4b406a74dc0449c0401ed87d5bfff4252fd277fd",
+                        "git_sha": "fdc08b8b1ae74f56686ce21f7ea11ad11990ce57",
                         "installed_by": ["subworkflows"]
                     }
                 }

--- a/modules/nf-core/gunzip/main.nf
+++ b/modules/nf-core/gunzip/main.nf
@@ -12,7 +12,7 @@ process GUNZIP {
 
     output:
     tuple val(meta), path("${gunzip}"), emit: gunzip
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('gunzip'), eval('gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//"'), topic: versions, emit: versions_gunzip
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,24 +32,14 @@ process GUNZIP {
         ${args} \\
         ${archive} \\
         > ${gunzip}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def extension = (archive.toString() - '.gz').tokenize('.')[-1]
     def name = archive.toString() - '.gz' - ".${extension}"
     def prefix = task.ext.prefix ?: name
     gunzip = prefix + ".${extension}"
     """
     touch ${gunzip}
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/gunzip/meta.yml
+++ b/modules/nf-core/gunzip/meta.yml
@@ -34,13 +34,29 @@ output:
           description: Compressed/uncompressed file
           pattern: "*.*"
           ontologies: []
+  versions_gunzip:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gunzip:
+          type: string
+          description: The tool name
+      - gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gunzip:
+          type: string
+          description: The tool name
+      - gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/gunzip/tests/main.nf.test.snap
+++ b/modules/nf-core/gunzip/tests/main.nf.test.snap
@@ -11,7 +11,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -21,16 +25,20 @@
                         "test.xyz.fastq:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-12-13T11:48:22.080222697"
+        "timestamp": "2026-01-19T17:21:56.633550769"
     },
     "Should run without failures - stub": {
         "content": [
@@ -44,7 +52,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -54,16 +66,20 @@
                         "test_1.fastq:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-12-13T11:48:14.593020264"
+        "timestamp": "2026-01-19T17:21:51.435621199"
     },
     "Should run without failures": {
         "content": [
@@ -77,7 +93,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -87,16 +107,20 @@
                         "test_1.fastq:md5,4161df271f9bfcd25d5845a1e220dbec"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-12-13T11:48:01.295397925"
+        "timestamp": "2026-01-19T17:21:40.613975821"
     },
     "Should run without failures - prefix": {
         "content": [
@@ -110,7 +134,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -120,15 +148,19 @@
                         "test.xyz.fastq:md5,4161df271f9bfcd25d5845a1e220dbec"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-12-13T11:48:07.414271387"
+        "timestamp": "2026-01-19T17:21:46.086880414"
     }
 }

--- a/modules/nf-core/minimap2/align/main.nf
+++ b/modules/nf-core/minimap2/align/main.nf
@@ -20,7 +20,7 @@ process MINIMAP2_ALIGN {
     tuple val(meta), path("*.paf")                       , optional: true, emit: paf
     tuple val(meta), path("*.bam")                       , optional: true, emit: bam
     tuple val(meta), path("*.bam.${bam_index_extension}"), optional: true, emit: index
-    path "versions.yml"                                  , emit: versions
+    tuple val("${task.process}"), val("minimap2"), eval("minimap2 --version"), topic: versions, emit: versions_minimap2
 
     when:
     task.ext.when == null || task.ext.when
@@ -52,11 +52,6 @@ process MINIMAP2_ALIGN {
         $bam_output
 
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        minimap2: \$(minimap2 --version 2>&1)
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
     """
 
     stub:
@@ -70,9 +65,5 @@ process MINIMAP2_ALIGN {
     touch $output_file
     ${bam_index}
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        minimap2: \$(minimap2 --version 2>&1)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/minimap2/align/meta.yml
+++ b/modules/nf-core/minimap2/align/meta.yml
@@ -85,13 +85,27 @@ output:
           description: BAM alignment index
           pattern: "*.bam.*"
           ontologies: []
+  versions_minimap2:
+    - - ${task.process}:
+          type: string
+          description: The process name
+      - minimap2:
+          type: string
+          description: The tool name
+      - minimap2 --version:
+          type: eval
+          description: The tool version
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process name
+      - minimap2:
+          type: string
+          description: The tool name
+      - minimap2 --version:
+          type: eval
+          description: The tool version
 authors:
   - "@heuermh"
   - "@sofstam"

--- a/modules/nf-core/minimap2/align/tests/main.nf.test
+++ b/modules/nf-core/minimap2/align/tests/main.nf.test
@@ -36,7 +36,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -71,7 +71,7 @@ nextflow_process {
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
                     file(process.out.index[0][1]).name,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -108,7 +108,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -142,7 +142,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -176,7 +176,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -211,7 +211,7 @@ nextflow_process {
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
                     file(process.out.index[0][1]).name,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }

--- a/modules/nf-core/minimap2/align/tests/main.nf.test.snap
+++ b/modules/nf-core/minimap2/align/tests/main.nf.test.snap
@@ -9,15 +9,21 @@
             ],
             "5d426b9a5f5b2c54f1d7f1e4c238ae94",
             "test.bam.bai",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:23.829797899"
+        "timestamp": "2026-01-22T15:02:10.851485367"
     },
     "sarscov2 - bam, fasta, true, 'bai', false, false - stub": {
         "content": [
@@ -44,7 +50,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ],
                 "bam": [
                     [
@@ -67,16 +77,20 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:54.665655242"
+        "timestamp": "2026-01-22T15:02:56.708796666"
     },
     "sarscov2 - fastq, fasta, true, 'bai', false, false - stub": {
         "content": [
@@ -103,7 +117,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ],
                 "bam": [
                     [
@@ -126,16 +144,20 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:38.492212433"
+        "timestamp": "2026-01-22T15:02:32.614463827"
     },
     "sarscov2 - fastq, fasta, false, [], false, false - stub": {
         "content": [
@@ -156,7 +178,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ],
                 "bam": [
                     
@@ -173,16 +199,20 @@
                         "test.paf:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:43.879647142"
+        "timestamp": "2026-01-22T15:02:40.02163098"
     },
     "sarscov2 - fastq, fasta, true, [], false, false - stub": {
         "content": [
@@ -203,7 +233,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ],
                 "bam": [
                     [
@@ -220,16 +254,20 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:33.262333471"
+        "timestamp": "2026-01-22T15:02:25.102539679"
     },
     "sarscov2 - [fastq1, fastq2], fasta, true, false, false": {
         "content": [
@@ -240,15 +278,21 @@
                 "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "1bc392244f228bf52cf0b5a8f6a654c9",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:07.571731983"
+        "timestamp": "2026-01-22T15:01:46.456636022"
     },
     "sarscov2 - fastq, fasta, true, [], false, false": {
         "content": [
@@ -259,15 +303,21 @@
                 "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "f194745c0ccfcb2a9c0aee094a08750",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:47:56.497792473"
+        "timestamp": "2026-01-22T15:01:30.525133177"
     },
     "sarscov2 - fastq, fasta, true, 'bai', false, false": {
         "content": [
@@ -279,15 +329,21 @@
             ],
             "f194745c0ccfcb2a9c0aee094a08750",
             "test.bam.bai",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:01.888544427"
+        "timestamp": "2026-01-22T15:01:38.84829029"
     },
     "sarscov2 - bam, fasta, true, [], false, false": {
         "content": [
@@ -298,15 +354,21 @@
                 "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "5d426b9a5f5b2c54f1d7f1e4c238ae94",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:18.376062313"
+        "timestamp": "2026-01-22T15:02:02.351060285"
     },
     "sarscov2 - bam, fasta, true, [], false, false - stub": {
         "content": [
@@ -327,7 +389,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ],
                 "bam": [
                     [
@@ -344,16 +410,20 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:49.268693724"
+        "timestamp": "2026-01-22T15:02:47.579634041"
     },
     "sarscov2 - fastq, [], true, false, false": {
         "content": [
@@ -463,14 +533,20 @@
                 "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "16c1c651f8ec67383bcdee3c55aed94f",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.29-r1283"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-04-22T14:48:12.942360555"
+        "timestamp": "2026-01-22T15:01:54.090788633"
     }
 }

--- a/subworkflows/local/align_ont.nf
+++ b/subworkflows/local/align_ont.nf
@@ -27,16 +27,14 @@ workflow ALIGN_ONT {
     SAMTOOLS_ADDREPLACERG ( CONVERT_CRAM.out.cram )
     ch_versions = ch_versions.mix ( SAMTOOLS_ADDREPLACERG.out.versions )
 
-    SAMTOOLS_ADDREPLACERG.out.cram
-    .set { ch_reads_cram }
+    ch_reads_cram = SAMTOOLS_ADDREPLACERG.out.cram
 
     // Index the CRAM file
     SAMTOOLS_INDEX ( ch_reads_cram )
     ch_versions = ch_versions.mix( SAMTOOLS_INDEX.out.versions )
 
-    ch_reads_cram
+    ch_reads_cram_crai = ch_reads_cram
     .join ( SAMTOOLS_INDEX.out.crai )
-    .set { ch_reads_cram_crai }
 
     //
     // MODULE: generate a CRAM CSV file containing the required parametres for CRAM_FILTER_MINIMAP2_FILTER5END_FIXMATE_SORT
@@ -53,12 +51,11 @@ workflow ALIGN_ONT {
     )
     ch_versions         = ch_versions.mix ( MINIMAP2_MAPREDUCE.out.versions )
 
-    ch_merged_bam
+    ch_merged_bam = ch_merged_bam
     .mix ( MINIMAP2_MAPREDUCE.out.mergedbam )
     .combine ( ch_reads_cram_crai )
     .filter { meta_bam, _bam, meta_cram, _cram, _crai -> meta_bam.id == meta_cram.id }
     .map { _meta_bam, bam, meta_cram, _cram, _crai -> [ meta_cram, bam ] }
-    .set { ch_merged_bam }
 
     //
     // SUBWORKFLOW: Merge all alignment output by sample name

--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -146,7 +146,6 @@ workflow ALIGN_PACBIO {
     // Align without map reduce
     // Align Fastq to Genome with minimap2. bam_format is set to true, making the output a *sorted* BAM
     MINIMAP2_ALIGN ( ch_reads_for_align, fasta, true, "csi", false, false )
-    ch_versions = ch_versions.mix ( MINIMAP2_ALIGN.out.versions.first() )
 
     MINIMAP2_ALIGN.out.bam
     .map { meta, file -> [meta.id, meta, file] }

--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -40,13 +40,12 @@ workflow ALIGN_PACBIO {
     ch_post_qc     = channel.empty()
 
     // Branch for handling ultra low-input libraries
-    reads
+    ch_reads_branched = reads
     .branch {
         meta, _reads ->
             uli : meta.library == "uli"
             other : true
     }
-    .set { ch_reads_branched }
 
     // Trim ULI adapter
     bam_for_md = ch_reads_branched.uli
@@ -59,9 +58,8 @@ workflow ALIGN_PACBIO {
     PACBIO_PBMARKDUP ( bam_for_md )
     ch_versions = ch_versions.mix ( PACBIO_PBMARKDUP.out.versions.first() )
 
-    PACBIO_PBMARKDUP.out.output
+    ch_reads_all = PACBIO_PBMARKDUP.out.output
     .mix ( ch_reads_branched.other )
-    .set { ch_reads_all }
 
     // Convert input to CRAM
     CONVERT_CRAM ( ch_reads_all, fasta )
@@ -74,9 +72,8 @@ workflow ALIGN_PACBIO {
     SAMTOOLS_INDEX ( SAMTOOLS_ADDREPLACERG.out.cram )
     ch_versions = ch_versions.mix( SAMTOOLS_INDEX.out.versions )
 
-    SAMTOOLS_ADDREPLACERG.out.cram
+    ch_reads_cram = SAMTOOLS_ADDREPLACERG.out.cram
     .join ( SAMTOOLS_INDEX.out.crai )
-    .set { ch_reads_cram }
 
     GENERATE_CRAM_CSV ( ch_reads_cram )
     ch_versions = ch_versions.mix ( GENERATE_CRAM_CSV.out.versions )
@@ -87,9 +84,8 @@ workflow ALIGN_PACBIO {
     //
     // FILTER BAMs AND OUTPUT AS FASTQ
     //
-    CREATE_CRAM_FILTER_INPUT.out.chunked_cram
+    ch_pacbio = CREATE_CRAM_FILTER_INPUT.out.chunked_cram
     .map { meta, cram -> [ meta, cram, [] ] }
-    .set { ch_pacbio }
 
     SAMTOOLS_CONVERT ( ch_pacbio, [ [], [] ], [], [] )
 
@@ -121,7 +117,7 @@ workflow ALIGN_PACBIO {
         ch_versions = ch_versions.mix ( TAR.out.versions )
 
         // REMERGE: fastq before post FASTQC, single-end to enable merging without pairing
-        ch_reads_for_align
+        ch_reads_to_remerge = ch_reads_for_align
         .map { meta, fastqs -> [ meta - [chunk_id: meta.chunk_id] + [ single_end: true ], fastqs ] }
         .groupTuple()
         .branch {
@@ -129,7 +125,6 @@ workflow ALIGN_PACBIO {
                 multi: fastqs.size() > 1
                 single : true
         }
-        .set { ch_reads_to_remerge }
 
         CAT_FASTQ ( ch_reads_to_remerge.multi )
 
@@ -147,11 +142,10 @@ workflow ALIGN_PACBIO {
     // Align Fastq to Genome with minimap2. bam_format is set to true, making the output a *sorted* BAM
     MINIMAP2_ALIGN ( ch_reads_for_align, fasta, true, "csi", false, false )
 
-    MINIMAP2_ALIGN.out.bam
+    collected_files_for_merge = MINIMAP2_ALIGN.out.bam
     .map { meta, file -> [meta.id, meta, file] }
     .groupTuple()
     .map { _id, metas, files -> [ metas[0] - [chunk_id: metas[0].chunk_id], files ] }
-    .set { collected_files_for_merge }
 
     //
     // MODULE: Merge chunked aligned bams

--- a/subworkflows/local/align_short.nf
+++ b/subworkflows/local/align_short.nf
@@ -17,13 +17,12 @@ workflow ALIGN_SHORT {
     ch_versions = channel.empty()
 
     // Check file types and branch
-    reads
+    ch_reads = reads
     .branch {
         _meta, reads_files ->
             fastq : reads_files.findAll { file -> file.getName().toLowerCase() =~ /.*f.*\.gz/ }
             cram : true
     }
-    .set { ch_reads }
 
 
     // Convert FASTQ to CRAM only if FASTQ were provided as input
@@ -33,9 +32,8 @@ workflow ALIGN_SHORT {
     SAMTOOLS_ADDREPLACERG ( CONVERT_CRAM.out.cram )
     ch_versions = ch_versions.mix ( SAMTOOLS_ADDREPLACERG.out.versions )
 
-    SAMTOOLS_ADDREPLACERG.out.cram
+    ch_reads_cram = SAMTOOLS_ADDREPLACERG.out.cram
     .mix ( ch_reads.cram )
-    .set { ch_reads_cram }
 
     ch_illumina = ch_reads_cram
     .combine(fasta)

--- a/subworkflows/local/convert_stats.nf
+++ b/subworkflows/local/convert_stats.nf
@@ -35,20 +35,18 @@ workflow CONVERT_STATS {
 
     // (Optionally) Compress the quality scores of Illumina and PacBio CCS alignments
     if ( params.compression == "crumble" ) {
-        bam
+        crumble_selector = bam
         .branch {
             meta, _bam ->
                 run_crumble: meta.datatype == "hic" || meta.datatype == "illumina" || meta.datatype == "pacbio"
                 no_crumble: true
         }
-        .set { crumble_selector }
 
         CRUMBLE ( crumble_selector.run_crumble, [], [] )
         ch_versions = ch_versions.mix( CRUMBLE.out.versions )
 
-        CRUMBLE.out.bam
+        ch_bams_for_renaming = CRUMBLE.out.bam
         .mix( crumble_selector.no_crumble )
-        .set { ch_bams_for_renaming }
     } else {
         ch_bams_for_renaming = bam
     }
@@ -56,9 +54,8 @@ workflow CONVERT_STATS {
     // Change name of BAM files to final name for publishing
     CHANGE_NAME ( ch_bams_for_renaming, fasta )
 
-    CHANGE_NAME.out.file
+    ch_renamed_bams = CHANGE_NAME.out.file
     .map { meta, bam_file -> [meta, bam_file, []] }
-    .set { ch_renamed_bams }
 
     // (Optionally) convert to CRAM if it's specified in outfmt
     ch_cram = channel.empty()

--- a/subworkflows/local/create_cram_filter_input.nf
+++ b/subworkflows/local/create_cram_filter_input.nf
@@ -10,7 +10,7 @@ workflow CREATE_CRAM_FILTER_INPUT {
     ch_versions = channel.empty()
 
     // Generate input channel for CRAM_FILTER
-    csv_ch
+    ch_cram_filter_input = csv_ch
     .splitCsv()
     .combine(fasta)
     .map { cram_id, cram_info, ref_id, ref_dir ->
@@ -34,7 +34,6 @@ workflow CREATE_CRAM_FILTER_INPUT {
             ref_dir
         )
     }
-    .set { ch_cram_filter_input }
 
     CRAM_FILTER ( ch_cram_filter_input )
     ch_versions = ch_versions.mix ( CRAM_FILTER.out.versions )

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -13,19 +13,17 @@ workflow INPUT_CHECK {
     ch_versions = channel.empty()
 
     // Prepare the samplesheet channel for SAMTOOLS_FLAGSTAT
-    ch_samplesheet
+    samplesheet_rows = ch_samplesheet
     .map { meta, file -> [meta, file, []] }
-    .set { samplesheet_rows }
 
     // Get stats from each input file
     SAMTOOLS_FLAGSTAT ( samplesheet_rows )
     ch_versions = ch_versions.mix ( SAMTOOLS_FLAGSTAT.out.versions.first() )
 
     // Create the read channel for the rest of the pipeline
-    samplesheet_rows
+    reads = samplesheet_rows
     .join( SAMTOOLS_FLAGSTAT.out.flagstat )
     .map { meta, datafile, _meta2, stats -> create_data_channel( meta, datafile, stats ) }
-    .set { reads }
 
 
     emit:

--- a/subworkflows/local/merge_output.nf
+++ b/subworkflows/local/merge_output.nf
@@ -13,12 +13,11 @@ workflow MERGE_OUTPUT {
     ch_bam = ch_bam.map{ meta, bam -> [ meta + [merged: false], bam ]}
 
     if ( params.merge_output ) {
-        ch_bam
+        ch_multi_bams = ch_bam
         .map { meta, bam -> [['id': meta.id.split('_')[0..-2].join('_'), 'datatype': meta.datatype], meta.read_count, bam] }
         .groupTuple( by: [0] )
         .map { meta, read_counts, bams -> [meta + [read_count: read_counts.sum()], bams] }
         .filter { _meta, bams -> bams.size() > 1 }
-        .set { ch_multi_bams }
 
         // Merge, but only if there is more than 1 file
         SAMTOOLS_MERGE ( ch_multi_bams, [ [], [] ], [ [], [] ], [ [], [] ] )

--- a/subworkflows/local/minimap2_mapreduce.nf
+++ b/subworkflows/local/minimap2_mapreduce.nf
@@ -29,7 +29,7 @@ workflow MINIMAP2_MAPREDUCE {
     //
     // LOGIC: generate input channel for mapping
     //
-    csv_ch
+    ch_filtering_input = csv_ch
     .splitCsv()
     .combine ( fasta )
     .combine ( MINIMAP2_INDEX.out.index )
@@ -51,7 +51,6 @@ workflow MINIMAP2_MAPREDUCE {
             ref_dir
         )
     }
-    .set { ch_filtering_input }
 
     //
     // MODULE: Map hic reads by 10,000 container per time
@@ -65,11 +64,10 @@ workflow MINIMAP2_MAPREDUCE {
     //
     // LOGIC: Preparing BAMs for merging
     //
-    mappedbam_ch
+    collected_files_for_merge = mappedbam_ch
     .map { meta, file -> [meta.id, meta, file] }
     .groupTuple()
     .map { _id, metas, files -> [ metas[0] - [chunk_id: metas[0].chunk_id], files ] }
-    .set { collected_files_for_merge }
 
     //
     // MODULE: Merge position sorted BAM files and mark duplicates

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -18,7 +18,6 @@ workflow PREPARE_GENOME {
     // Uncompress genome fasta file if required
     if ( params.fasta.endsWith('.gz') ) {
         ch_unzipped = GUNZIP ( fasta ).gunzip
-        ch_versions = ch_versions.mix ( GUNZIP.out.versions )
     } else {
         ch_unzipped = fasta
     }

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -22,9 +22,8 @@ workflow PREPARE_GENOME {
         ch_unzipped = fasta
     }
 
-    ch_unzipped
+    ch_fasta = ch_unzipped
     .map { meta, fa -> [ meta + [id: fa.baseName, genome_size: fa.size()], fa] }
-    .set { ch_fasta }
 
     // Unmask genome fasta
     UNMASK ( ch_fasta )
@@ -33,10 +32,9 @@ workflow PREPARE_GENOME {
     // Generate BWA index
     if ( checkShortReads( params.input ) ) {
         if ( params.bwamem2_index ) {
-            channel.fromPath ( params.bwamem2_index )
+            ch_bwamem = channel.fromPath ( params.bwamem2_index )
             .combine ( ch_fasta )
             .map { bwa, meta, _fa -> [ meta, bwa ] }
-            .set { ch_bwamem }
 
             if ( params.bwamem2_index.endsWith('.tar.gz') ) {
                 ch_bwamem2_index = UNTAR ( ch_bwamem ).untar

--- a/subworkflows/local/utils_nfcore_readmapping_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_readmapping_pipeline/main.nf
@@ -124,15 +124,13 @@ workflow PIPELINE_INITIALISATION {
     // Create channel from input file provided through params.input
     //
 
-    channel
+    ch_samplesheet = channel
         .fromList(samplesheetToList(params.input, "${projectDir}/assets/schema_input.json"))
         .map { meta, datafile ->
             def new_meta = meta + [id: file(datafile).baseName]
             return [new_meta, datafile]
         }
-        .set { ch_samplesheet }
-    validateInputSamplesheet(ch_samplesheet)
-        .set { ch_validated_samplesheet }
+    ch_validated_samplesheet = validateInputSamplesheet(ch_samplesheet)
 
     emit:
     samplesheet = ch_validated_samplesheet

--- a/subworkflows/nf-core/utils_nfschema_plugin/main.nf
+++ b/subworkflows/nf-core/utils_nfschema_plugin/main.nf
@@ -38,7 +38,7 @@ workflow UTILS_NFSCHEMA_PLUGIN {
         }
         log.info paramsHelp(
             help_options,
-            params.help instanceof String ? params.help : "",
+            (params.help instanceof String && params.help != "true") ? params.help : "",
         )
         exit 0
     }
@@ -71,4 +71,3 @@ workflow UTILS_NFSCHEMA_PLUGIN {
     emit:
     dummy_emit = true
 }
-

--- a/subworkflows/nf-core/utils_nfschema_plugin/tests/nextflow.config
+++ b/subworkflows/nf-core/utils_nfschema_plugin/tests/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-    id "nf-schema@2.5.1"
+    id "nf-schema@2.6.1"
 }
 
 validation {

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -61,8 +61,7 @@
                     "hifi_trimmer": "1.2.2"
                 },
                 "MINIMAP2_ALIGN": {
-                    "minimap2": "2.29-r1283",
-                    "samtools": 1.21
+                    "minimap2": "2.29-r1283"
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
@@ -196,8 +195,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-30T18:36:31.542603598"
+        "timestamp": "2026-02-07T18:58:43.372479666"
     }
 }

--- a/tests/test_uli.nf.test.snap
+++ b/tests/test_uli.nf.test.snap
@@ -50,8 +50,7 @@
                     "lima": "2.12.0"
                 },
                 "MINIMAP2_ALIGN": {
-                    "minimap2": "2.29-r1283",
-                    "samtools": 1.21
+                    "minimap2": "2.29-r1283"
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
@@ -123,8 +122,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-30T18:51:43.097151506"
+        "timestamp": "2026-02-07T19:07:38.796279284"
     }
 }

--- a/tests/test_untrim.nf.test.snap
+++ b/tests/test_untrim.nf.test.snap
@@ -46,8 +46,7 @@
                     "gzip": 1.1
                 },
                 "MINIMAP2_ALIGN": {
-                    "minimap2": "2.29-r1283",
-                    "samtools": 1.21
+                    "minimap2": "2.29-r1283"
                 },
                 "MINIMAP2_INDEX": {
                     "minimap2": "2.29-r1283"
@@ -170,8 +169,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-30T19:07:30.792459271"
+        "timestamp": "2026-02-07T19:17:46.827757961"
     }
 }

--- a/workflows/readmapping.nf
+++ b/workflows/readmapping.nf
@@ -60,7 +60,7 @@ workflow READMAPPING {
     //
     // SUBWORKFLOW: Read in samplesheet, validate and stage input files
     //
-    INPUT_CHECK ( ch_samplesheet ).reads
+    ch_reads = INPUT_CHECK ( ch_samplesheet ).reads
     .branch {
         meta, _reads ->
             short_ : meta.datatype == "hic" || meta.datatype == "illumina"
@@ -68,13 +68,11 @@ workflow READMAPPING {
             clr : meta.datatype == "pacbio_clr"
             ont : meta.datatype == "ont"
     }
-    .set { ch_reads }
 
     ch_versions = ch_versions.mix ( INPUT_CHECK.out.versions )
 
-    ch_fasta
+    ch_genome = ch_fasta
     .map { fasta -> [ [ id: fasta.baseName ], fasta ] }
-    .set { ch_genome }
 
     PREPARE_GENOME ( ch_genome )
     ch_versions = ch_versions.mix ( PREPARE_GENOME.out.versions )
@@ -82,12 +80,11 @@ workflow READMAPPING {
     //
     // Control quality of input files
     //
-    INPUT_CHECK.out.reads
+    ch_fastqc_reads = INPUT_CHECK.out.reads
     .branch { _meta, reads ->
                 cram:  reads.getName().endsWith("cram")
                 other: true
     }
-    .set { ch_fastqc_reads }
 
     // Convert cram to FASTQs
     SAMTOOLS_COLLATETOFASTQ ( ch_fastqc_reads.cram, true )
@@ -106,13 +103,11 @@ workflow READMAPPING {
     // ***PacBio condition does not work - needs fixing***
     if ( ch_reads.pacbio || ch_reads.clr ) {
         if ( params.hifi_adapter_db.endsWith( '.tar.gz' ) ) {
-            UNTAR ( [ [:], params.hifi_adapter_db ] ).untar
-            .set { ch_hifi_adapter_db }
+            ch_hifi_adapter_db = UNTAR ( [ [:], params.hifi_adapter_db ] ).untar
             ch_versions = ch_versions.mix ( UNTAR.out.versions )
 
         } else {
-            channel.fromPath ( params.hifi_adapter_db )
-            .set { ch_hifi_adapter_db }
+            ch_hifi_adapter_db = channel.fromPath ( params.hifi_adapter_db )
         }
     }
 
@@ -171,14 +166,14 @@ workflow READMAPPING {
             "${process}:\n${tool_versions.join('\n')}"
         }
 
-    softwareVersionsToYAML(ch_versions.mix(topic_versions.versions_file))
+    ch_collated_versions = softwareVersionsToYAML(ch_versions.mix(topic_versions.versions_file))
         .mix(topic_versions_string)
         .collectFile(
             storeDir: "${params.outdir}/pipeline_info",
             name:  'readmapping_software_mqc_'  + 'versions.yml',
             sort: true,
             newLine: true
-        ).set { ch_collated_versions }
+        )
 
     reports = reports.map { _meta, file -> file }
 


### PR DESCRIPTION
`.set` and `|` are deprecated though not yet flagged by `nextflow lint`.

I started updated nf-core modules but there are 3 more, waiting for https://github.com/nf-core/modules/pull/9926

<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
