### PR TITLE
Handle empty barcode

### DIFF
--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -4,5 +4,5 @@ SAMEA7524439,ERR6688600,illumina,https://tolit.cog.sanger.ac.uk/test-data/Meles_
 SAMEA7524440,ERR6688402,hic,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/hic/35528_2_1.subset.cram,,
 SAMEA7524440,PAE35587,ont,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/ont/PAE35587_pass_1f1f0707_115.subset.fastq.gz,,
 SAMEA7524440,PAE35587_test,ont,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/ont/PAE35587_pass_1f1f0707_115.subset.addrg.bam,,
-SAMEA7524440,ERR6939248,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/pacbio/m64094_200910_173211.ccs.bc1022_BAK8B_OA--bc1022_BAK8B_OA.subset.bam,,bc1022
+SAMEA7524440,ERR6939248,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/pacbio/m64094_200910_173211.ccs.bc1022_BAK8B_OA--bc1022_BAK8B_OA.subset.bam,,
 SAMEA7524440,ERR6939249,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/genomic_data/mMelMel3/pacbio/m64094_200911_174739.ccs.bc1022_BAK8B_OA--bc1022_BAK8B_OA.subset.fastq.gz,,bc1022

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ This pipeline aligns raw reads from various technolgies (such as HiC, Illumina, 
 
 ## Samplesheet input
 
-You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 6 columns, and a header row as shown in the examples below.
+You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with a header row as shown in the examples below. The first 4 columns are required (`specimen`, `run`, `datatype`, `datafile`), while `library` and `barcode` are optional.
 
 ```bash
 --input '[path to samplesheet file]'
@@ -33,9 +33,9 @@ A final samplesheet file consisting of both HiC and PacBio data may look somethi
 
 ```console
 specimen,run,datatype,datafile,library,barcode
-specimen1,run1,hic1.cram,,
-specimen1,run2,hic2.cram,,
-specimen2,run3,hic3.cram,,
+specimen1,run1,hic,hic1.cram,,
+specimen1,run2,hic,hic2.cram,,
+specimen2,run3,hic,hic3.cram,,
 specimen2,run4,pacbio,pacbio1.bam,uli,
 specimen3,run5,pacbio,pacbio2.bam,,
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,7 +47,7 @@ specimen3,run5,pacbio,pacbio2.bam,,
 | `datatype` | Type of sequencing data. Must be one of `hic`, `illumina`, `pacbio`, `pacbio_clr`, or `ont`.                                                                                                                                                |
 | `datafile` | Full path to read data file. Must be `bam`, `cram`, `fastq.gz` or `fq.gz` for `illumina` and `hic`. Must be `bam`, `fastq.gz` or `fq.gz` for `pacbio`, `pacbio_clr`, and `ont`. Note that FASTQ inputs should be interleaved if paired-end. |
 | `library`  | (Optional) The library value is a unique identifier which is assigned to read group (`@RG`) ID. If the library name is not specified, the pipeline will auto-create library name using the data filename provided in the samplesheet.       |
-| `barcode`  | (Optional) Barcode identifier used to trim barcode adapater for PacBio reads                                                                                                                                                                |
+| `barcode`  | (Optional) Barcode identifier used to trim barcode adapter for PacBio reads                                                                                                                                                                 |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ This pipeline aligns raw reads from various technolgies (such as HiC, Illumina, 
 
 ## Samplesheet input
 
-You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 4 columns, and a header row as shown in the examples below.
+You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 6 columns, and a header row as shown in the examples below.
 
 ```bash
 --input '[path to samplesheet file]'
@@ -32,12 +32,12 @@ The samplesheet can have as many columns as you desire, however, there is a stri
 A final samplesheet file consisting of both HiC and PacBio data may look something like the one below.
 
 ```console
-specimen,run,datatype,datafile,library
-specimen1,run1,hic1.cram,
-specimen1,run2,hic2.cram,
-specimen2,run3,hic3.cram,
-specimen2,run4,pacbio,pacbio1.bam,uli
-specimen3,run5,pacbio,pacbio2.bam,
+specimen,run,datatype,datafile,library,barcode
+specimen1,run1,hic1.cram,,
+specimen1,run2,hic2.cram,,
+specimen2,run3,hic3.cram,,
+specimen2,run4,pacbio,pacbio1.bam,uli,
+specimen3,run5,pacbio,pacbio2.bam,,
 ```
 
 | Column     | Description                                                                                                                                                                                                                                 |
@@ -47,6 +47,7 @@ specimen3,run5,pacbio,pacbio2.bam,
 | `datatype` | Type of sequencing data. Must be one of `hic`, `illumina`, `pacbio`, `pacbio_clr`, or `ont`.                                                                                                                                                |
 | `datafile` | Full path to read data file. Must be `bam`, `cram`, `fastq.gz` or `fq.gz` for `illumina` and `hic`. Must be `bam`, `fastq.gz` or `fq.gz` for `pacbio`, `pacbio_clr`, and `ont`. Note that FASTQ inputs should be interleaved if paired-end. |
 | `library`  | (Optional) The library value is a unique identifier which is assigned to read group (`@RG`) ID. If the library name is not specified, the pipeline will auto-create library name using the data filename provided in the samplesheet.       |
+| `barcode`  | (Optional) Barcode identifier used to trim barcode adapater for PacBio reads                                                                                                                                                                |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 

--- a/subworkflows/local/align_long.nf
+++ b/subworkflows/local/align_long.nf
@@ -83,11 +83,14 @@ workflow ALIGN_LONG {
         if (val_pacbio_adapter_fasta && val_pacbio_adapter_yaml) {
             ch_yaml_meta = ch_reads.pacbio
                 .combine( channel.fromPath(val_pacbio_adapter_yaml, checkIfExists: true) )
-                .map { meta, _reads, yaml -> [ meta, yaml ]
+                .map{ meta, _reads, yaml -> [ meta, yaml ]}
+                .branch { meta, yaml ->
+                    has_barcode: meta.barcode != null && !meta.barcode.isEmpty()
+                    no_barcode: true
                 }
-
-            GAWK_MODIFY_YAML_BARCODE( ch_yaml_meta, [], false )
-            ch_pacbio_read_yaml = ch_reads.pacbio.combine(GAWK_MODIFY_YAML_BARCODE.out.output, by: 0)
+            GAWK_MODIFY_YAML_BARCODE( ch_yaml_meta.has_barcode, [], false )
+            ch_yml_barcoded = GAWK_MODIFY_YAML_BARCODE.out.output.mix( ch_yaml_meta.no_barcode )
+            ch_pacbio_read_yaml = ch_reads.pacbio.combine(ch_yml_barcoded, by: 0)
             adapter_fasta_for_preprocess = [[id:file( val_pacbio_adapter_fasta ).baseName], val_pacbio_adapter_fasta]
         } else {
             ch_pacbio_read_yaml = ch_reads.pacbio.map { meta, read_files -> [ meta, read_files, [] ] } //PacBio reads with dummy yaml

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test": {
         "content": [
-            176,
+            175,
             {
                 "BGZIP_BEDGRAPH": {
                     "samtools": "1.23.1"
@@ -257,24 +257,24 @@
                 "GCA_922984935.2.subset.ont.SAMEA7524440.merged_1.minimap2.flagstat:md5,ec6aaeb8be068f8b35a56d091d38c8b0",
                 "GCA_922984935.2.subset.ont.SAMEA7524440.merged_1.minimap2.idxstats:md5,5e872e9487a31f09266c6a73b3dbbd38",
                 "GCA_922984935.2.subset.ont.SAMEA7524440.merged_1.minimap2.stats.gz:md5,b2196feb830687c0f303effdd7a2ad94",
-                "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939248.minimap2.coverage.1k.bedGraph.gz:md5,5ad4ef58cd155a1b9f56f65ee02e6084",
-                "pacbio.SAMEA7524440.ERR6939248.hifitrimmer.bed.gz:md5,0fe5fe224b52d743066bb3e03fecd982",
+                "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939248.minimap2.coverage.1k.bedGraph.gz:md5,f7e99e6b9fa95ba67f7fe1486bcce1f6",
+                "pacbio.SAMEA7524440.ERR6939248.hifitrimmer.bed.gz:md5,3002179a24e3db9145f57460622eb02f",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939248.minimap2.flagstat:md5,db1610f3490d314de7e60f10d404178d",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939248.minimap2.idxstats:md5,f757bd37fc1461e576348525ae0ba087",
-                "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939248.minimap2.stats.gz:md5,f727dbd990a67c58a91c9c53d0cb6bf2",
+                "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939248.minimap2.stats.gz:md5,4e1533437cc4fd9c0525150391755520",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939249.minimap2.coverage.1k.bedGraph.gz:md5,adf81ade1a26064658861318edfb5df1",
                 "pacbio.SAMEA7524440.ERR6939249.hifitrimmer.bed.gz:md5,16e8458843c0a6e1736f19c297088c32",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939249.minimap2.flagstat:md5,81a2332a3cdcc6b37dd2687d2cc77752",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939249.minimap2.idxstats:md5,fe8b829d5241701b172cf4ff55cbf4f6",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.ERR6939249.minimap2.stats.gz:md5,91cee5cca6ffa7c8c566791f4f514ee8",
-                "GCA_922984935.2.subset.pacbio.SAMEA7524440.merged_1.minimap2.coverage.1k.bedGraph.gz:md5,c39c1c0a440f49d83722da029b9bcf5f",
+                "GCA_922984935.2.subset.pacbio.SAMEA7524440.merged_1.minimap2.coverage.1k.bedGraph.gz:md5,1546e51cd6c63db37014daaa518b3cfe",
                 "SOURCE.txt:md5,343a5205e5b93005576ee69a0869dad3",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.merged_1.minimap2.flagstat:md5,da9dcde0937f27935637db67c14c9928",
                 "GCA_922984935.2.subset.pacbio.SAMEA7524440.merged_1.minimap2.idxstats:md5,ee312e0f5e6053bc81b737ae5805807f",
-                "GCA_922984935.2.subset.pacbio.SAMEA7524440.merged_1.minimap2.stats.gz:md5,9ac83c1939cdee8e020cfba523c89f33"
+                "GCA_922984935.2.subset.pacbio.SAMEA7524440.merged_1.minimap2.stats.gz:md5,d0afecc3b0dc7c3dda2fb8684c5cec7a"
             ],
             {
-
+                
             },
             {
                 "GCA_922984935.2.subset.hic.SAMEA7524440.ERR6688402.bwamem2.cram": {
@@ -378,7 +378,7 @@
                 }
             },
             [
-                "pacbio.SAMEA7524440.ERR6939248.hifitrimmer.summary.json:md5,81572321148a5e77738af902fa5f9e71",
+                "pacbio.SAMEA7524440.ERR6939248.hifitrimmer.summary.json:md5,d2d4198c3f7086437249909d94173359",
                 "pacbio.SAMEA7524440.ERR6939249.hifitrimmer.summary.json:md5,83d9985a6d7a4477df704d8f4a23852c"
             ]
         ],
@@ -386,6 +386,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T19:29:08.956210749"
+        "timestamp": "2026-05-15T12:13:39.841579495"
     }
 }


### PR DESCRIPTION
`TruSeq_i7s_UDI005, TruSeq_i5_UDP009, TruSeq_i7_UDP002, TruSeq_D707, TruSeq_i7s_UDI004 in the BLAST table match to more than one adapter defined in the YAML!`
This error is due to when a barcode is not provided, this leave a empty string and this empty string will match all the adapter name.
<!--
# sanger-tol/readmapping pull request

Many thanks for contributing to sanger-tol/readmapping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/readmapping/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/readmapping/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
